### PR TITLE
fix: cross-platform base64

### DIFF
--- a/example/spectral/build.sh
+++ b/example/spectral/build.sh
@@ -11,7 +11,7 @@ echo "2. Extracting policy.wasm from bundle..."
 tar -xzf ./build/bundle.tar.gz -C ./build /policy.wasm 2>&1 | grep -v "Removing leading"
 
 echo "3. Converting Wasm file into a base64-decoded string: ./wasm.js"
-wasm=$(base64 ./build/policy.wasm)
+wasm=$(openssl base64 -A -in ./build/policy.wasm)
 echo "exports.policyWasmBuffer = Buffer.from(\`$wasm\`, 'base64');" >./wasm.js
 
 echo "4. Extracting annotations: ./policies.js"


### PR DESCRIPTION
I was playing with Spego and discovered that base64 command line in Mac takes an extra option `-i`, I found out that `openssl base64 -A` is cross-platform

@kevinswiber let me know if it's not the case for you.